### PR TITLE
ignore build bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.lock-wscript


### PR DESCRIPTION
To facilitate mountain-gorilla builds of CA that use this as a git submodule.

Without this the CA repo is always "dirty" after a build:

```
$ git status
...
#       modified:   deps/node-libdtrace
...
```
